### PR TITLE
fix: change version from 1.2.11 to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.keycloak.extensions</groupId>
     <artifactId>keycloak-discord</artifactId>
-    <version>1.2.11</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
I believe this is a typo, it's causing the nix build to fail because we're looking for a jar that matches the version